### PR TITLE
Normalize email adress(#67)

### DIFF
--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -35,7 +35,8 @@ export default {
             rules: [
               { type: 'email', message: 'The input is not valid e-mail.' },
               { required: true, message: 'Please input your e-mail.' }
-            ]
+            ],
+            normalize: value => value.toLowerCase()
           }
         ],
         password: [

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -42,7 +42,8 @@ export default {
             rules: [
               { type: 'email', message: 'E-mail is not valid.' },
               { required: true, message: 'E-mail is required.' }
-            ]
+            ],
+            normalize: value => value.toLowerCase()
           }
         ],
         password: [


### PR DESCRIPTION
While register or login the letters of the e-mail address must be all lowercase. Otherwise, these values cannot match.